### PR TITLE
Swap discord link to guild.xyz

### DIFF
--- a/packages/frontend/src/Components/Intro/index.tsx
+++ b/packages/frontend/src/Components/Intro/index.tsx
@@ -90,11 +90,14 @@ const Intro: FC<IntroProps> = ({ heading, subHeading }) => {
                 borderColor: 'black',
               }}
               onClick={() => {
-                window.open('https://discord.gg/devdao', '_blank');
+                window.open('https://www.guild.xyz/dd', '_blank');
               }}
             >
               <Box as={FaDiscord} mr=".75rem" fontSize="2rem" />
-              Join Discord
+              <Box>
+                <Text>Join Discord</Text>
+                <Text fontSize="0.75rem">(via Guild.xyz)</Text>
+              </Box>
             </Button>
           </Flex>
         </Box>


### PR DESCRIPTION
### What does it do?
Swaps the Discord invite link to the Guild.xyz one

### Any helpful background information?
See #28, but basically need to push people through guild.xyz first

### Any new dependencies? Why were they added?
No

### Relevant screenshots/gifs
![image](https://user-images.githubusercontent.com/8845353/188778698-1a140c84-3ca0-4c4f-a0c3-e73a7328c19b.png)

### Does it close any issues?

Closes #28
