### PR TITLE
Issue #49 - removing stale code references

### DIFF
--- a/packages/frontend/src/Components/Intro/index.tsx
+++ b/packages/frontend/src/Components/Intro/index.tsx
@@ -53,8 +53,8 @@ const Intro: FC<IntroProps> = ({ heading, subHeading }) => {
           >
             {t(subHeading!)}
           </Text>
-          <Flex justifyContent="center" w="100" mt="3rem">
-            <Button
+          <Flex justifyContent="start" w="100" mt="3rem">
+            {/* <Button
               px="1.5rem"
               border="1px solid black"
               borderRadius="0.625rem"
@@ -72,22 +72,22 @@ const Intro: FC<IntroProps> = ({ heading, subHeading }) => {
               }}
             >
               Claim $CODE
-            </Button>
+            </Button> */}
 
             <Button
               px="1.5rem"
               border="1px solid white"
               borderRadius="0.625rem"
-              bg="black"
-              color="white"
+              maxW={{ base: '75%', md: '20rem' }}
+              bg="white"
+              color="black"
               flexGrow={1}
               py={{ base: '1.75rem', xl: '2rem' }}
-              ml={{ base: '1.25rem', xl: '2rem' }}
+              // ml={{ base: '0', xl: '2rem' }}
               fontSize={{ base: '0.875rem', xl: '1.25rem' }}
               _hover={{
-                bg: 'white',
-                color: 'black',
-                borderColor: 'black',
+                bg: 'black',
+                color: 'white',
               }}
               onClick={() => {
                 window.open('https://www.guild.xyz/dd', '_blank');

--- a/packages/frontend/src/layout/index.tsx
+++ b/packages/frontend/src/layout/index.tsx
@@ -22,7 +22,7 @@ function Layout({
   const { colorMode } = useColorMode();
   return (
     <Box>
-      <Marquee
+      {/* <Marquee
         style={{
           background: `${colorMode === 'dark' ? '#ffffff' : '#000000'}`,
           width: '100%',
@@ -45,7 +45,7 @@ function Layout({
             </ReactMarkdown>
           ))}
         </HStack>
-      </Marquee>
+      </Marquee> */}
       <Stack
         paddingY="2.06rem"
         paddingX={{ base: '16px', md: '4px', lg: '48px' }}
@@ -57,7 +57,7 @@ function Layout({
           <FooterComponent data={footer!} />
         </>
       </Stack>
-      <Marquee
+      {/* <Marquee
         style={{
           background: `${colorMode === 'light' ? '#ffffff' : '#000000'}`,
           width: '100%',
@@ -80,7 +80,7 @@ function Layout({
             </ReactMarkdown>
           ))}
         </HStack>
-      </Marquee>
+      </Marquee> */}
     </Box>
   );
 }


### PR DESCRIPTION
### What does it do?

Quick and first fix to comment out the references to $CODE claim on the site. Top/Bottom Marquee banner and home page button.

### Any helpful background information?

$CODE Claim ended on Feb 18th.

### Any new dependencies? Why were they added?

Nope

### Relevant screenshots/gifs

### Does it close any issues?

Closes #49 
